### PR TITLE
always prepend accountIdBuffer

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -143,7 +143,6 @@ export class AlgorandApp extends BaseApp {
   ) {
     const chunks = []
 
-    // First chunk prepend accountId if != 0
     let messageBuffer
 
     if (typeof message === 'string') {
@@ -152,15 +151,9 @@ export class AlgorandApp extends BaseApp {
       messageBuffer = message
     }
 
-    let buffer: Buffer
-
-    if (accountId !== 0) {
-      const accountIdBuffer = Buffer.alloc(4)
-      accountIdBuffer.writeUInt32BE(accountId)
-      buffer = Buffer.concat([accountIdBuffer, messageBuffer])
-    } else {
-      buffer = Buffer.concat([messageBuffer])
-    }
+    const accountIdBuffer = Buffer.alloc(4)
+    accountIdBuffer.writeUInt32BE(accountId)
+    const buffer = Buffer.concat([accountIdBuffer, messageBuffer])
 
     for (let i = 0; i < buffer.length; i += AlgorandApp._params.chunkSize) {
       let end = i + AlgorandApp._params.chunkSize


### PR DESCRIPTION
The current logic to only prepend the `accountId` to the message `if (accountId !== 0)`. This breaks signing with the 0-index account (S+ v2.1.14) with the following error:

`Data is invalid : Msgpack unexpected type`

Please consider this change to always prepend the `accountId`. The [@ledgerhq/hw-app-algorand](https://www.npmjs.com/package/@ledgerhq/hw-app-algorand) package always prepends that value and works as desired.